### PR TITLE
remove unnecessary nil checks before calling len() on slices

### DIFF
--- a/mocks.go
+++ b/mocks.go
@@ -73,7 +73,7 @@ func (r *Transport) RoundTrip(req *http.Request) (mockResponse *http.Response, e
 		r.debug.mock(mockResponse, req)
 	}()
 
-	if r.observers != nil && len(r.observers) > 0 {
+	if len(r.observers) > 0 {
 		defer func() {
 			for _, observe := range r.observers {
 				observe(mockResponse, req, r.specTest)


### PR DESCRIPTION
this PR removes unnecessary nil checks before calling `len()` on slices.,
```
var slice []byte // equal to nil, default value for a slice
if slice != nil && len(slice) > 0 {}
// is the same as
if len(slice) > 0 {}
```
because `len(slice)` where slice == nil is always equal to 0,

`staticcheck` will highlight this optimization with the following message:
```
mocks.go:76:5: should omit nil check; len() for []github.com/nao1215/spectest.Observe is defined as zero (S1009)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Simplified observer check logic in the `RoundTrip` method
	- Removed redundant nil check for observers

<!-- end of auto-generated comment: release notes by coderabbit.ai -->